### PR TITLE
Fix Typo in serialize_argument Deprecation Warning

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -98,7 +98,7 @@ module ActiveJob
               Primitive serialization of BigDecimal job arguments is deprecated as it may serialize via .to_s using certain queue adapters.
               Enable config.active_job.use_big_decimal_serializer to use BigDecimalSerializer instead, which will be mandatory in Rails 7.2.
 
-              Note that if you application has multiple replicas, you should only enable this setting after successfully deploying your app to Rails 7.1 first.
+              Note that if your application has multiple replicas, you should only enable this setting after successfully deploying your app to Rails 7.1 first.
               This will ensure that during your deployment all replicas are capable of deserializing arguments serialized with BigDecimalSerializer.
             MSG
             return argument

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -64,7 +64,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
       Primitive serialization of BigDecimal job arguments is deprecated as it may serialize via .to_s using certain queue adapters.
       Enable config.active_job.use_big_decimal_serializer to use BigDecimalSerializer instead, which will be mandatory in Rails 7.2.
 
-      Note that if you application has multiple replicas, you should only enable this setting after successfully deploying your app to Rails 7.1 first.
+      Note that if your application has multiple replicas, you should only enable this setting after successfully deploying your app to Rails 7.1 first.
       This will ensure that during your deployment all replicas are capable of deserializing arguments serialized with BigDecimalSerializer.
     MSG
       assert_equal(


### PR DESCRIPTION
This PR addresses a minor typo in the deprecation warning of the serialize_argument method.

Original:
"...This will ensure that during you deployment all replicas are capable of deserializing arguments serialized with BigDecimalSerializer."

Corrected:
"...This will ensure that during your deployment all replicas are capable of deserializing arguments serialized with BigDecimalSerializer."

Maintaining accurate and clear messaging is essential, especially for deprecation warnings that guide developers through potential upgrade paths or changes in behavior.